### PR TITLE
✨[Feat] : 전시회/게시판 작성 #29

### DIFF
--- a/src/main/java/com/example/artstoryage/controller/PostController.java
+++ b/src/main/java/com/example/artstoryage/controller/PostController.java
@@ -1,0 +1,52 @@
+package com.example.artstoryage.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.artstoryage.annotation.auth.AuthMember;
+import com.example.artstoryage.common.BaseResponse;
+import com.example.artstoryage.converter.PostConverter;
+import com.example.artstoryage.domain.member.Member;
+import com.example.artstoryage.dto.request.PostRequestDto.*;
+import com.example.artstoryage.dto.response.PostResponseDto.*;
+import com.example.artstoryage.exception.GlobalErrorCode;
+import com.example.artstoryage.service.PostCommandService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/post")
+@Tag(name = "📋 Post", description = "전시회/게시판 관련 API")
+public class PostController {
+
+  private final PostCommandService postCommandService;
+
+  @Operation(summary = "게시글 등록 API", description = "게시글 정보를 등록합니다")
+  @ApiResponses({@ApiResponse(responseCode = "201", description = "성공")})
+  @PostMapping("/")
+  @ResponseStatus(HttpStatus.CREATED)
+  public BaseResponse<CreatePostResponse> createArtist(
+      @Parameter(hidden = true) @AuthMember Member member, @RequestBody CreatePostRequest request) {
+    return BaseResponse.onSuccess(
+        GlobalErrorCode.CREATED,
+        PostConverter.toCreatePostResponse(postCommandService.createPost(request, member)));
+  }
+
+  @Operation(summary = "전시회 등록 API", description = "전시회 정보를 등록합니다")
+  @ApiResponses({@ApiResponse(responseCode = "201", description = "성공")})
+  @PostMapping("/exhibit")
+  @ResponseStatus(HttpStatus.CREATED)
+  public BaseResponse<CreatePostResponse> createExhibition(
+      @Parameter(hidden = true) @AuthMember Member member,
+      @RequestBody CreateExhibitionRequest request) {
+    return BaseResponse.onSuccess(
+        GlobalErrorCode.CREATED,
+        PostConverter.toCreatePostResponse(postCommandService.createExhibition(request, member)));
+  }
+}

--- a/src/main/java/com/example/artstoryage/converter/PostConverter.java
+++ b/src/main/java/com/example/artstoryage/converter/PostConverter.java
@@ -1,0 +1,51 @@
+package com.example.artstoryage.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.example.artstoryage.domain.Outline;
+import com.example.artstoryage.domain.Post;
+import com.example.artstoryage.domain.enums.PostCategory;
+import com.example.artstoryage.domain.member.Member;
+import com.example.artstoryage.dto.request.PostRequestDto.*;
+import com.example.artstoryage.dto.response.PostResponseDto.CreatePostResponse;
+
+@Component
+public class PostConverter {
+
+  public static Post toPost(CreatePostRequest request, Member member) {
+    return Post.builder()
+        .postCategory(PostCategory.POST)
+        .title(request.getTitle())
+        .content(request.getContent())
+        .view(0L)
+        .member(member)
+        .build();
+  }
+
+  public static Post toExhibition(CreateExhibitionRequest request, Member member) {
+    return Post.builder()
+        .postCategory(PostCategory.EXHIBITION)
+        .title(request.getTitle())
+        .content(request.getContent())
+        .view(0L)
+        .member(member)
+        .outline(
+            Outline.builder()
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .siteUrl(request.getSiteUrl())
+                .businessHours(request.getBusinessHours())
+                .address(request.getAddress())
+                .tags(request.getTags())
+                .build())
+        .build();
+  }
+
+  public static CreatePostResponse toCreatePostResponse(Post post) {
+    return CreatePostResponse.builder()
+        .postId(post.getId())
+        .title(post.getTitle())
+        .postCategory(post.getPostCategory())
+        .build();
+  }
+}

--- a/src/main/java/com/example/artstoryage/domain/Outline.java
+++ b/src/main/java/com/example/artstoryage/domain/Outline.java
@@ -1,0 +1,31 @@
+package com.example.artstoryage.domain;
+
+import jakarta.persistence.*;
+
+import com.example.artstoryage.domain.common.BaseEntity;
+
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Outline extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String startDate;
+
+  private String endDate;
+
+  private String siteUrl;
+
+  private String businessHours;
+
+  private String address;
+
+  private String tags;
+}

--- a/src/main/java/com/example/artstoryage/domain/Post.java
+++ b/src/main/java/com/example/artstoryage/domain/Post.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import com.example.artstoryage.domain.common.BaseEntity;
 import com.example.artstoryage.domain.enums.PostCategory;
 import com.example.artstoryage.domain.mapping.Comment;
+import com.example.artstoryage.domain.member.Member;
 
 import lombok.*;
 
@@ -36,4 +37,11 @@ public class Post extends BaseEntity {
 
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
   private List<PostImage> postImages = new ArrayList<>();
+
+  @OneToOne(fetch = FetchType.LAZY)
+  private Member member;
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @JoinColumn(name = "outline")
+  private Outline outline;
 }

--- a/src/main/java/com/example/artstoryage/domain/Post.java
+++ b/src/main/java/com/example/artstoryage/domain/Post.java
@@ -38,7 +38,8 @@ public class Post extends BaseEntity {
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
   private List<PostImage> postImages = new ArrayList<>();
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member")
   private Member member;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/example/artstoryage/domain/enums/PostCategory.java
+++ b/src/main/java/com/example/artstoryage/domain/enums/PostCategory.java
@@ -1,3 +1,6 @@
 package com.example.artstoryage.domain.enums;
 
-public enum PostCategory {}
+public enum PostCategory {
+  EXHIBITION,
+  POST
+}

--- a/src/main/java/com/example/artstoryage/domain/member/Member.java
+++ b/src/main/java/com/example/artstoryage/domain/member/Member.java
@@ -6,6 +6,7 @@ import java.util.List;
 import jakarta.persistence.*;
 
 import com.example.artstoryage.domain.Artist;
+import com.example.artstoryage.domain.Post;
 import com.example.artstoryage.domain.common.BaseEntity;
 import com.example.artstoryage.domain.enums.MemberRole;
 import com.example.artstoryage.domain.enums.SocialType;
@@ -61,6 +62,9 @@ public class Member extends BaseEntity {
 
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
   private List<Comment> comments = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+  private List<Post> posts = new ArrayList<>();
 
   public void setMemberTerms(List<MemberTerm> memberTerms) {
     this.memberTerms = memberTerms;

--- a/src/main/java/com/example/artstoryage/dto/request/PostRequestDto.java
+++ b/src/main/java/com/example/artstoryage/dto/request/PostRequestDto.java
@@ -1,0 +1,25 @@
+package com.example.artstoryage.dto.request;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+public class PostRequestDto {
+
+  @Getter
+  @SuperBuilder
+  public static class CreatePostRequest {
+    String title;
+    String content;
+  }
+
+  @Getter
+  @SuperBuilder
+  public static class CreateExhibitionRequest extends CreatePostRequest {
+    String startDate;
+    String endDate;
+    String siteUrl;
+    String businessHours;
+    String address;
+    String tags;
+  }
+}

--- a/src/main/java/com/example/artstoryage/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/artstoryage/dto/response/PostResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.artstoryage.dto.response;
+
+import com.example.artstoryage.domain.enums.PostCategory;
+
+import lombok.*;
+
+public class PostResponseDto {
+
+  @Getter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class CreatePostResponse {
+    Long postId;
+    String title;
+    PostCategory postCategory;
+  }
+}

--- a/src/main/java/com/example/artstoryage/exception/custom/PostException.java
+++ b/src/main/java/com/example/artstoryage/exception/custom/PostException.java
@@ -1,0 +1,11 @@
+package com.example.artstoryage.exception.custom;
+
+import com.example.artstoryage.exception.GlobalErrorCode;
+import com.example.artstoryage.exception.GlobalException;
+
+public class PostException extends GlobalException {
+
+  public PostException(GlobalErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/example/artstoryage/repository/PostRepository.java
+++ b/src/main/java/com/example/artstoryage/repository/PostRepository.java
@@ -1,0 +1,12 @@
+package com.example.artstoryage.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.artstoryage.domain.Post;
+import com.example.artstoryage.domain.enums.PostCategory;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+  Optional<Post> findByPostCategory(PostCategory postCategory);
+}

--- a/src/main/java/com/example/artstoryage/service/PostCommandService.java
+++ b/src/main/java/com/example/artstoryage/service/PostCommandService.java
@@ -1,0 +1,12 @@
+package com.example.artstoryage.service;
+
+import com.example.artstoryage.domain.Post;
+import com.example.artstoryage.domain.member.Member;
+import com.example.artstoryage.dto.request.PostRequestDto;
+
+public interface PostCommandService {
+
+  Post createPost(PostRequestDto.CreatePostRequest request, Member member);
+
+  Post createExhibition(PostRequestDto.CreateExhibitionRequest request, Member member);
+}

--- a/src/main/java/com/example/artstoryage/service/impl/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/artstoryage/service/impl/PostCommandServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.artstoryage.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.artstoryage.converter.PostConverter;
+import com.example.artstoryage.domain.Post;
+import com.example.artstoryage.domain.member.Member;
+import com.example.artstoryage.dto.request.PostRequestDto;
+import com.example.artstoryage.dto.request.PostRequestDto.CreatePostRequest;
+import com.example.artstoryage.repository.PostRepository;
+import com.example.artstoryage.service.PostCommandService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostCommandServiceImpl implements PostCommandService {
+
+  private final PostRepository postRepository;
+
+  @Override
+  public Post createPost(CreatePostRequest request, Member member) {
+    return postRepository.save(PostConverter.toPost(request, member));
+  }
+
+  @Override
+  public Post createExhibition(PostRequestDto.CreateExhibitionRequest request, Member member) {
+    return postRepository.save(PostConverter.toExhibition(request, member));
+  }
+}

--- a/src/test/java/com/example/artstoryage/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/example/artstoryage/service/PostCommandServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.example.artstoryage.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.example.artstoryage.domain.Post;
+import com.example.artstoryage.domain.enums.MemberRole;
+import com.example.artstoryage.domain.enums.SocialType;
+import com.example.artstoryage.domain.member.Member;
+import com.example.artstoryage.domain.member.Password;
+import com.example.artstoryage.dto.request.PostRequestDto;
+import com.example.artstoryage.repository.PostRepository;
+import com.example.artstoryage.service.impl.PostCommandServiceImpl;
+
+class PostCommandServiceImplTest {
+  @Mock private PostRepository postRepository;
+  @InjectMocks private PostCommandServiceImpl postCommandService;
+
+  private Member member;
+
+  private PostRequestDto.CreatePostRequest createPostRequest;
+  private PostRequestDto.CreateExhibitionRequest createExhibitionRequest;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    member =
+        Member.builder()
+            .name("name")
+            .nickName("nickname")
+            .email("email")
+            .password(Password.encrypt("Test1234!@#$", new BCryptPasswordEncoder()))
+            .phoneNumber("010-0000-0000")
+            .socialType(SocialType.Common)
+            .memberRole(MemberRole.USER)
+            .build();
+  }
+
+  @Test
+  void createPost_success() {
+    createPostRequest =
+        PostRequestDto.CreatePostRequest.builder().title("title").content("content").build();
+    // Exhibition(Post) 저장 시 값 반환 설정
+    given(postRepository.save(any(Post.class))).willAnswer(invocation -> invocation.getArgument(0));
+    Post result = postCommandService.createPost(createPostRequest, member);
+    assertNotNull(result);
+    assertEquals(result.getTitle(), createPostRequest.getTitle());
+    assertEquals(result.getTitle(), createPostRequest.getTitle());
+  }
+
+  @Test
+  void createExhibition() {
+    createExhibitionRequest =
+        PostRequestDto.CreateExhibitionRequest.builder()
+            .title("title")
+            .content("content")
+            .startDate("2024-01-01")
+            .endDate("2024-12-31")
+            .siteUrl("www.aaa.com")
+            .businessHours("0시부터 12시까지")
+            .address("서울시 중구")
+            .tags("#을지로")
+            .build();
+    // Exhibition(Post) 저장 시 값 반환 설정
+    given(postRepository.save(any(Post.class))).willAnswer(invocation -> invocation.getArgument(0));
+    Post result = postCommandService.createExhibition(createExhibitionRequest, member);
+    assertNotNull(result);
+    assertEquals(result.getTitle(), createExhibitionRequest.getTitle());
+    assertEquals(result.getOutline().getStartDate(), createExhibitionRequest.getStartDate());
+  }
+}


### PR DESCRIPTION
# 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

# ❗️ 관련 이슈 링크
Close #29 

# 📌 개요
- 전시회 create
- 게시글 create

# 🔁 변경 사항
- 전시회 작성(Controller, Service, Repository, Dto, Converter)
- 게시판 작성(Controller, Service, Repository, Dto, Converter)
- Outline Entity 추가
- Post Entity에 Member와 Outline 관계 추가

# 👀 기타 더 이야기해볼 점
현재 Post가 Outline Entity를 OneToOne으로 가지는 형식으로 작성되어 있음. 전시회와 게시판의 요청 타입이 다르기 때문에 RequestDto를 분리하고 대신 상속(extends 및 @SuperBuilder 사용)을 활용할 수 밖에 없었는데 만약 문제가 된다면 바꿔야할 수 있음

# ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.